### PR TITLE
Include command name when printing command usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,7 @@ $ reactor create -h
 This command creates a component of a given type and outputs component files in the project directory.
 
 Usage:
-   reactor <name> [version] [files] {flags}
+   reactor create <name> [version] [files] {flags}
 
 Arguments: 
    name                          name of the component to create 

--- a/commando.go
+++ b/commando.go
@@ -496,6 +496,7 @@ func (cr *CommandRegistry) PrintHelp(c *Command) {
 		Args          []*Arg
 		Flags         map[string]*Flag
 		Commands      map[string]*Command
+		Command       string
 	}{
 		CliDesc:       cr.Desc,
 		Executable:    exeName,
@@ -504,6 +505,7 @@ func (cr *CommandRegistry) PrintHelp(c *Command) {
 		Args:          arguments,
 		Flags:         c.Flags,
 		Commands:      commands,
+		Command:       c.clpCommandConfig.Name,
 	}
 
 	// parse help template

--- a/templates.go
+++ b/templates.go
@@ -4,7 +4,7 @@ var usageTemplate = `
 {{ if .IsRootCommand }}{{ .CliDesc }}{{ else }}{{ .Desc }}{{ end }}
 
 Usage:
-   {{ .Executable }} {{ with .Args -}}
+   {{ .Executable }} {{ if not .IsRootCommand }}{{ .Command }} {{ end }}{{ with .Args -}}
    {{ range $k, $v := . }}{{ if $v.IsRequired }}<{{ $v.ClpArg.Name }}>{{ else }}[{{ $v.ClpArg.Name }}]{{ end }} {{ end }}{{ end }}{flags}{{- if .IsRootCommand }}{{ if .Commands }}
    {{ .Executable }} <command> {flags}{{ end }}{{ end -}}
 


### PR DESCRIPTION
The command usage was misleading because it was including the command itself:

```
$ reactor create -h

Usage:
   reactor <name> [version] [files] {flags}
```

We now include the name of the command in the usage section:

```
$ reactor create -h

Usage:
   reactor create <name> [version] [files] {flags}
```